### PR TITLE
Fix done blink bug and swap hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Task Samurai invokes the `task` command to read and modify tasks. The tasks are 
 
 - `e` or `E`: edit task
 - `s`: toggle start/stop
-- `D`: mark task done
+- `d`: mark task done
 - `U`: undo last done
-- `d`: set due date
+- `D`: set due date
 - `r`: random due date
 - `R`: edit recurrence
 - `a`: annotate task

--- a/internal/ui/table_test.go
+++ b/internal/ui/table_test.go
@@ -162,7 +162,7 @@ func TestDoneHotkey(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
+	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
 	m = mv.(Model)
 	for i := 0; i < blinkCycles; i++ {
 		mv, _ = m.Update(blinkMsg{})
@@ -211,7 +211,7 @@ func TestUndoHotkey(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
+	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
 	m = mv.(Model)
 	for i := 0; i < blinkCycles; i++ {
 		mv, _ = m.Update(blinkMsg{})
@@ -269,7 +269,7 @@ func TestDueDateHotkey(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
 	m = mv.(Model)
 	for i := 0; i < 3; i++ {
 		mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyRight})


### PR DESCRIPTION
## Summary
- prevent task modifications from automatically marking tasks done
- swap `D` and `d` hotkeys
- update help text and documentation
- adjust unit tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6857bcee25b08321b94608b0b97afa89