### PR TITLE
Fix done marking bug and swap hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ Task Samurai invokes the `task` command to read and modify tasks. The tasks are 
 
 - `e` or `E`: edit task
 - `s`: toggle start/stop
- - `d`: mark task done
- - `U`: undo last done
- - `D`: set due date
+- `d`: mark task done
+- `U`: undo last done
+- `D`: set due date
+- `+`: add task
 - `r`: random due date
 - `R`: edit recurrence
 - `a`: annotate task
@@ -54,4 +55,6 @@ Task Samurai invokes the `task` command to read and modify tasks. The tasks are 
 - `C`: reset theme
 - `H`: toggle help
 - `q` or `esc`: close search/help or quit (press `q` when nothing is open)
+
+Example: press `+`, type `Buy milk` and hit Enter to add a new task called "Buy milk".
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Task Samurai invokes the `task` command to read and modify tasks. The tasks are 
 - `d`: mark task done
 - `U`: undo last done
 - `D`: set due date
+- `T`: run task command
 - `+`: add task
 - `r`: random due date
 - `R`: edit recurrence
@@ -57,4 +58,5 @@ Task Samurai invokes the `task` command to read and modify tasks. The tasks are 
 - `q` or `esc`: close search/help or quit (press `q` when nothing is open)
 
 Example: press `+`, type `Buy milk` and hit Enter to add a new task called "Buy milk".
+Example: press `T`, type `+bg modify +huhu` to tag all `+bg` tasks with `+huhu`.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Task Samurai invokes the `task` command to read and modify tasks. The tasks are 
 - `d`: mark task done
 - `U`: undo last done
 - `D`: set due date
-- `T`: run task command
 - `+`: add task
 - `r`: random due date
 - `R`: edit recurrence
@@ -58,5 +57,4 @@ Task Samurai invokes the `task` command to read and modify tasks. The tasks are 
 - `q` or `esc`: close search/help or quit (press `q` when nothing is open)
 
 Example: press `+`, type `Buy milk` and hit Enter to add a new task called "Buy milk".
-Example: press `T`, type `+bg modify +huhu` to tag all `+bg` tasks with `+huhu`.
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Task Samurai invokes the `task` command to read and modify tasks. The tasks are 
 
 - `e` or `E`: edit task
 - `s`: toggle start/stop
-- `D`: mark task done
-- `U`: undo last done
-- `d`: set due date
+ - `d`: mark task done
+ - `U`: undo last done
+ - `D`: set due date
 - `r`: random due date
 - `R`: edit recurrence
 - `a`: annotate task

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQ
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -86,6 +86,24 @@ func AddLine(line string) error {
 	return AddArgs(fields)
 }
 
+// RunArgs executes "task" with the given arguments. Each item in args is
+// passed as a separate command-line argument.
+func RunArgs(args []string) error {
+	cmd := exec.Command("task", args...)
+	return cmd.Run()
+}
+
+// RunLine splits the provided line into shell words and executes "task" with
+// the resulting arguments. This allows callers to run arbitrary Taskwarrior
+// commands directly.
+func RunLine(line string) error {
+	fields, err := shlex.Split(line)
+	if err != nil {
+		return err
+	}
+	return RunArgs(fields)
+}
+
 // Export retrieves all tasks using `task export rc.json.array=off` and parses
 // the JSON output into a slice of Task structs.
 // Export retrieves tasks using `task <filter> export rc.json.array=off` and parses

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -86,24 +86,6 @@ func AddLine(line string) error {
 	return AddArgs(fields)
 }
 
-// RunArgs executes "task" with the given arguments. Each item in args is
-// passed as a separate command-line argument.
-func RunArgs(args []string) error {
-	cmd := exec.Command("task", args...)
-	return cmd.Run()
-}
-
-// RunLine splits the provided line into shell words and executes "task" with
-// the resulting arguments. This allows callers to run arbitrary Taskwarrior
-// commands directly.
-func RunLine(line string) error {
-	fields, err := shlex.Split(line)
-	if err != nil {
-		return err
-	}
-	return RunArgs(fields)
-}
-
 // Export retrieves all tasks using `task export rc.json.array=off` and parses
 // the JSON output into a slice of Task structs.
 // Export retrieves tasks using `task <filter> export rc.json.array=off` and parses

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -484,7 +484,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				for _, tsk := range m.tasks {
 					oldIDs[tsk.ID] = struct{}{}
 				}
-				task.Add(m.addInput.Value(), nil)
+				task.AddLine(m.addInput.Value())
 				m.addingTask = false
 				m.addInput.Blur()
 				m.reload()

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -849,7 +849,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // View renders the table UI.
 func (m Model) View() string {
 	if m.showHelp {
-		return lipgloss.JoinVertical(lipgloss.Left,
+		lines := []string{
 			m.tbl.HelpView(),
 			"enter/i: edit or expand cell",
 			"E: edit task",
@@ -872,7 +872,11 @@ func (m Model) View() string {
 			"esc: close help/search",
 			"q: quit",
 			"H: help", // show help toggle line
-		)
+		}
+		for i, l := range lines {
+			lines[i] = centerLines(l, m.tbl.Width())
+		}
+		return lipgloss.JoinVertical(lipgloss.Top, lines...)
 	}
 	view := lipgloss.JoinVertical(lipgloss.Left,
 		m.topStatusLine(),
@@ -1362,4 +1366,13 @@ func (m *Model) applyTheme() {
 	m.tblStyles.Selected = m.tblStyles.Selected.Foreground(lipgloss.Color(m.theme.SelectedFG)).Background(lipgloss.Color(m.theme.SelectedBG))
 	m.tblStyles.Highlight = m.tblStyles.Highlight.Background(lipgloss.Color(m.theme.RowBG)).Foreground(lipgloss.Color(m.theme.RowFG))
 	m.tbl.SetStyles(m.tblStyles)
+}
+
+func centerLines(s string, width int) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	style := lipgloss.NewStyle().Width(width).Align(lipgloss.Center)
+	for i, l := range lines {
+		lines[i] = style.Render(l)
+	}
+	return strings.Join(lines, "\n")
 }

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -64,9 +64,6 @@ type Model struct {
 	addingTask bool
 	addInput   textinput.Model
 
-	runningTask bool
-	taskInput   textinput.Model
-
 	searching     bool
 	searchInput   textinput.Model
 	searchRegex   *regexp.Regexp
@@ -169,9 +166,6 @@ func New(filters []string) (Model, error) {
 
 	m.addInput = textinput.New()
 	m.addInput.Prompt = "add: "
-
-	m.taskInput = textinput.New()
-	m.taskInput.Prompt = "task: "
 
 	m.defaultTheme = DefaultTheme()
 	m.theme = m.defaultTheme
@@ -523,46 +517,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.addInput, cmd = m.addInput.Update(msg)
 			return m, cmd
 		}
-		if m.runningTask {
-			switch msg.Type {
-			case tea.KeyEnter:
-				oldIDs := make(map[int]struct{})
-				for _, tsk := range m.tasks {
-					oldIDs[tsk.ID] = struct{}{}
-				}
-				task.RunLine(m.taskInput.Value())
-				m.runningTask = false
-				m.taskInput.Blur()
-				m.reload()
-				var newID int
-				row := -1
-				for i, tsk := range m.tasks {
-					if _, ok := oldIDs[tsk.ID]; !ok {
-						newID = tsk.ID
-						row = i
-						break
-					}
-				}
-				m.updateTableHeight()
-				if row >= 0 {
-					prevRow := m.tbl.Cursor()
-					prevCol := m.tbl.ColumnCursor()
-					m.tbl.SetCursor(row)
-					m.tbl.SetColumnCursor(7)
-					m.updateSelectionHighlight(prevRow, m.tbl.Cursor(), prevCol, m.tbl.ColumnCursor())
-					return m, m.startBlink(newID, false)
-				}
-				return m, nil
-			case tea.KeyEsc:
-				m.runningTask = false
-				m.taskInput.Blur()
-				m.updateTableHeight()
-				return m, nil
-			}
-			var cmd tea.Cmd
-			m.taskInput, cmd = m.taskInput.Update(msg)
-			return m, cmd
-		}
 		if m.searching {
 			switch msg.Type {
 			case tea.KeyEnter:
@@ -756,12 +710,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.addInput.Focus()
 			m.updateTableHeight()
 			return m, nil
-		case "T":
-			m.runningTask = true
-			m.taskInput.SetValue("")
-			m.taskInput.Focus()
-			m.updateTableHeight()
-			return m, nil
 		case "t":
 			if row := m.tbl.SelectedRow(); row != nil {
 				idStr := ansi.Strip(row[1])
@@ -905,7 +853,6 @@ func (m Model) View() string {
 			m.tbl.HelpView(),
 			"enter/i: edit or expand cell",
 			"E: edit task",
-			"T: run task command",
 			"+: add task",
 			"s: toggle start/stop",
 			"d: mark task done",
@@ -985,12 +932,6 @@ func (m Model) View() string {
 		view = lipgloss.JoinVertical(lipgloss.Left,
 			view,
 			m.addInput.View(),
-		)
-	}
-	if m.runningTask {
-		view = lipgloss.JoinVertical(lipgloss.Left,
-			view,
-			m.taskInput.View(),
 		)
 	}
 	if m.searching {
@@ -1306,7 +1247,7 @@ func (m *Model) updateTableHeight() {
 	if m.cellExpanded {
 		h--
 	}
-	if m.annotating || m.dueEditing || m.prioritySelecting || m.searching || m.descEditing || m.tagsEditing || m.recurEditing || m.filterEditing || m.addingTask || m.runningTask {
+	if m.annotating || m.dueEditing || m.prioritySelecting || m.searching || m.descEditing || m.tagsEditing || m.recurEditing || m.filterEditing || m.addingTask {
 		h--
 	}
 	if h < 1 {

--- a/internal/ui/table_test.go
+++ b/internal/ui/table_test.go
@@ -476,7 +476,7 @@ func TestAddHotkey(t *testing.T) {
 
 	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'+'}})
 	m = mv.(Model)
-	for _, r := range "task" {
+	for _, r := range "foo due:today" {
 		mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
 		m = mv.(Model)
 	}
@@ -488,7 +488,7 @@ func TestAddHotkey(t *testing.T) {
 		t.Fatalf("read add: %v", err)
 	}
 
-	if strings.TrimSpace(string(data)) != "add task" {
+	if strings.TrimSpace(string(data)) != "add foo due:today" {
 		t.Fatalf("add not called: %q", data)
 	}
 }

--- a/internal/ui/table_test.go
+++ b/internal/ui/table_test.go
@@ -442,6 +442,57 @@ func TestPriorityHotkey(t *testing.T) {
 	}
 }
 
+func TestAddHotkey(t *testing.T) {
+	tmp := t.TempDir()
+	taskPath := filepath.Join(tmp, "task")
+	addFile := filepath.Join(tmp, "add.txt")
+
+	script := "#!/bin/sh\n" +
+		"if echo \"$@\" | grep -q export; then\n" +
+		"  echo '{\"id\":1,\"uuid\":\"x\",\"description\":\"d\",\"status\":\"pending\",\"entry\":\"\",\"priority\":\"\",\"urgency\":0}'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"echo \"$@\" > " + addFile + "\n"
+
+	if err := os.WriteFile(taskPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", tmp+":"+origPath)
+	t.Cleanup(func() { os.Setenv("PATH", origPath) })
+
+	os.Setenv("TASKDATA", tmp)
+	os.Setenv("TASKRC", "/dev/null")
+	t.Cleanup(func() {
+		os.Unsetenv("TASKDATA")
+		os.Unsetenv("TASKRC")
+	})
+
+	m, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'+'}})
+	m = mv.(Model)
+	for _, r := range "task" {
+		mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = mv.(Model)
+	}
+	mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = mv.(Model)
+
+	data, err := os.ReadFile(addFile)
+	if err != nil {
+		t.Fatalf("read add: %v", err)
+	}
+
+	if strings.TrimSpace(string(data)) != "add task" {
+		t.Fatalf("add not called: %q", data)
+	}
+}
+
 func TestNavigationHotkeys(t *testing.T) {
 	tmp := t.TempDir()
 	taskPath := filepath.Join(tmp, "task")

--- a/internal/ui/table_test.go
+++ b/internal/ui/table_test.go
@@ -493,57 +493,6 @@ func TestAddHotkey(t *testing.T) {
 	}
 }
 
-func TestTaskHotkey(t *testing.T) {
-	tmp := t.TempDir()
-	taskPath := filepath.Join(tmp, "task")
-	cmdFile := filepath.Join(tmp, "cmd.txt")
-
-	script := "#!/bin/sh\n" +
-		"if echo \"$@\" | grep -q export; then\n" +
-		"  echo '{\"id\":1,\"uuid\":\"x\",\"description\":\"d\",\"status\":\"pending\",\"entry\":\"\",\"priority\":\"\",\"urgency\":0}'\n" +
-		"  exit 0\n" +
-		"fi\n" +
-		"echo \"$@\" > " + cmdFile + "\n"
-
-	if err := os.WriteFile(taskPath, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", tmp+":"+origPath)
-	t.Cleanup(func() { os.Setenv("PATH", origPath) })
-
-	os.Setenv("TASKDATA", tmp)
-	os.Setenv("TASKRC", "/dev/null")
-	t.Cleanup(func() {
-		os.Unsetenv("TASKDATA")
-		os.Unsetenv("TASKRC")
-	})
-
-	m, err := New(nil)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-
-	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'T'}})
-	m = mv.(Model)
-	for _, r := range "+bg modify +huhu" {
-		mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
-		m = mv.(Model)
-	}
-	mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	m = mv.(Model)
-
-	data, err := os.ReadFile(cmdFile)
-	if err != nil {
-		t.Fatalf("read cmd: %v", err)
-	}
-
-	if strings.TrimSpace(string(data)) != "+bg modify +huhu" {
-		t.Fatalf("task not called: %q", data)
-	}
-}
-
 func TestNavigationHotkeys(t *testing.T) {
 	tmp := t.TempDir()
 	taskPath := filepath.Join(tmp, "task")

--- a/internal/ui/table_test.go
+++ b/internal/ui/table_test.go
@@ -162,7 +162,7 @@ func TestDoneHotkey(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
+	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
 	m = mv.(Model)
 	for i := 0; i < blinkCycles; i++ {
 		mv, _ = m.Update(blinkMsg{})
@@ -211,7 +211,7 @@ func TestUndoHotkey(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
+	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
 	m = mv.(Model)
 	for i := 0; i < blinkCycles; i++ {
 		mv, _ = m.Update(blinkMsg{})
@@ -269,7 +269,7 @@ func TestDueDateHotkey(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
 	m = mv.(Model)
 	for i := 0; i < 3; i++ {
 		mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyRight})


### PR DESCRIPTION
## Summary
- avoid marking tasks as done when edited
- blink tasks on edit without completing them
- swap hotkeys so `d` marks done and `D` edits due date
- update help text and README
- adjust tests for new hotkeys

## Testing
- `go fmt ./...`
- `go test ./...`
- `apt-get update`
- `apt-get install -y taskwarrior`

------
https://chatgpt.com/codex/tasks/task_e_6857c1fa18188321b9e84a17d8541017