### PR TITLE
Update module path and installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,19 @@ Example: press `+`, type `Buy milk` and hit Enter to add a new task called "Buy 
 
 ![Task Samurai screenshot](screenshot.png)
 
+## Installation
+
+There are two ways to install the `tasksamurai` command:
+
+```bash
+go install codeberg.org/snonux/tasksamurai/cmd/tasksamurai@latest
+```
+
+Alternatively, clone this repository and run:
+
+```bash
+go-task install
+```
+
+The second method requires [go-task](https://taskfile.dev/) to be installed.
+

--- a/cmd/tasksamurai/main.go
+++ b/cmd/tasksamurai/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"tasksamurai/internal/task"
-	"tasksamurai/internal/ui"
+	"codeberg.org/snonux/tasksamurai/internal/task"
+	"codeberg.org/snonux/tasksamurai/internal/ui"
 
 	tea "github.com/charmbracelet/bubbletea"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module tasksamurai
+module codeberg.org/snonux/tasksamurai
 
 go 1.23.8
 
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.5
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.8.0
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 )
 
 require (
@@ -16,7 +17,6 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -14,9 +14,9 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"tasksamurai/internal"
-	atable "tasksamurai/internal/atable"
-	"tasksamurai/internal/task"
+	"codeberg.org/snonux/tasksamurai/internal"
+	atable "codeberg.org/snonux/tasksamurai/internal/atable"
+	"codeberg.org/snonux/tasksamurai/internal/task"
 )
 
 var priorityOptions = []string{"H", "M", "L", ""}

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,4 +1,4 @@
 package internal
 
 // Version is the current version of Task Samurai.
-const Version = "0.0.1"
+const Version = "0.9.0"


### PR DESCRIPTION
## Summary
- rename module to `codeberg.org/snonux/tasksamurai`
- update import paths accordingly
- bump Task Samurai version to `0.9.0`
- document installation via `go install` or `go-task`

## Testing
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68581232cd7c8321aa3627796528cc4c