### PR TITLE
Add space hotkey for refreshing tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Task Samurai invokes the `task` command to read and modify tasks. The tasks are 
 - `↑/k` and `↓/j`: move up and down
 - `←/h` and `→/l`: move left and right
 - `b/pgup`: page up
-- `pgdn/space`: page down
+- `pgdn`: page down
 - `u` or `ctrl+u`: half page up
 - `ctrl+d`: half page down
 - `g/home/0`: go to start
@@ -53,6 +53,7 @@ Task Samurai invokes the `task` command to read and modify tasks. The tasks are 
 - `f`: change filter
 - `c`: random theme
 - `C`: reset theme
+- `space`: refresh tasks
 - `H`: toggle help
 - `q` or `esc`: close search/help or quit (press `q` when nothing is open)
 

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -304,13 +304,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, blinkCmd()
 		}
 		return m, nil
-       case tea.KeyMsg:
-                // Ignore all key presses while a task is blinking to avoid
-                // accidentally modifying another task.
-                if m.blinkID != 0 {
-                        return m, nil
-                }
-                if m.annotating {
+	case tea.KeyMsg:
+		// Ignore all key presses while a task is blinking to avoid
+		// accidentally modifying another task.
+		if m.blinkID != 0 {
+			return m, nil
+		}
+		if m.annotating {
 			switch msg.Type {
 			case tea.KeyEnter:
 				if m.replaceAnnotations {
@@ -738,6 +738,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.theme = m.defaultTheme
 			m.applyTheme()
 			return m, nil
+		case " ":
+			m.reload()
+			return m, nil
 		case "/", "?":
 			m.searching = true
 			m.searchInput.SetValue("")
@@ -874,6 +877,7 @@ func (m Model) View() string {
 			"t: edit tags",
 			"c: random theme",
 			"C: reset theme",
+			"space: refresh tasks",
 			"/, ?: search",
 			"n/N: next/prev search match",
 			"esc: close help/search",


### PR DESCRIPTION
## Summary
- refresh task list with the space bar
- document the new hotkey in README and help screen

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68584e5f59ac8321b78641b9183bda5b