### PR TITLE
Add URL open hotkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Task Samurai invokes the `task` command to read and modify tasks. The tasks are 
 - `e` or `E`: edit task
 - `s`: toggle start/stop
 - `d`: mark task done
+- `o`: open URL from description
 - `U`: undo last done
 - `D`: set due date
 - `+`: add task

--- a/cmd/tasksamurai/main.go
+++ b/cmd/tasksamurai/main.go
@@ -13,6 +13,7 @@ import (
 
 func main() {
 	debugLog := flag.String("debug-log", "", "path to debug log file")
+	browserCmd := flag.String("browser-cmd", "firefox", "command used to open URLs")
 	flag.Parse()
 
 	if err := task.SetDebugLog(*debugLog); err != nil {
@@ -20,7 +21,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	m, err := ui.New(flag.Args())
+	m, err := ui.New(flag.Args(), *browserCmd)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "failed to load tasks:", err)
 		os.Exit(1)

--- a/internal/ui/table_test.go
+++ b/internal/ui/table_test.go
@@ -41,7 +41,7 @@ func TestAnnotateHotkey(t *testing.T) {
 		os.Unsetenv("TASKRC")
 	})
 
-	m, err := New(nil)
+	m, err := New(nil, "firefox")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestReplaceAnnotationHotkey(t *testing.T) {
 		os.Unsetenv("TASKRC")
 	})
 
-	m, err := New(nil)
+	m, err := New(nil, "firefox")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestDoneHotkey(t *testing.T) {
 		os.Unsetenv("TASKRC")
 	})
 
-	m, err := New(nil)
+	m, err := New(nil, "firefox")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -206,7 +206,7 @@ func TestUndoHotkey(t *testing.T) {
 		os.Unsetenv("TASKRC")
 	})
 
-	m, err := New(nil)
+	m, err := New(nil, "firefox")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -237,6 +237,55 @@ func TestUndoHotkey(t *testing.T) {
 	}
 }
 
+func TestOpenURLHotkey(t *testing.T) {
+	tmp := t.TempDir()
+	taskPath := filepath.Join(tmp, "task")
+	openFile := filepath.Join(tmp, "open.txt")
+	browserPath := filepath.Join(tmp, "browser")
+
+	taskScript := "#!/bin/sh\n" +
+		"if echo \"$@\" | grep -q export; then\n" +
+		"  echo '{\"id\":1,\"uuid\":\"x\",\"description\":\"see https://example.com\",\"status\":\"pending\",\"entry\":\"\",\"priority\":\"\",\"urgency\":0}'\n" +
+		"  exit 0\n" +
+		"fi\n"
+	if err := os.WriteFile(taskPath, []byte(taskScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	browserScript := "#!/bin/sh\n" +
+		"echo $1 > " + openFile + "\n"
+	if err := os.WriteFile(browserPath, []byte(browserScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", tmp+":"+origPath)
+	t.Cleanup(func() { os.Setenv("PATH", origPath) })
+
+	os.Setenv("TASKDATA", tmp)
+	os.Setenv("TASKRC", "/dev/null")
+	t.Cleanup(func() {
+		os.Unsetenv("TASKDATA")
+		os.Unsetenv("TASKRC")
+	})
+
+	m, err := New(nil, browserPath)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}})
+	m = mv.(Model)
+
+	data, err := os.ReadFile(openFile)
+	if err != nil {
+		t.Fatalf("read open: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "https://example.com" {
+		t.Fatalf("browser not called with url: %q", data)
+	}
+}
+
 func TestDueDateHotkey(t *testing.T) {
 	tmp := t.TempDir()
 	taskPath := filepath.Join(tmp, "task")
@@ -264,7 +313,7 @@ func TestDueDateHotkey(t *testing.T) {
 		os.Unsetenv("TASKRC")
 	})
 
-	m, err := New(nil)
+	m, err := New(nil, "firefox")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -316,7 +365,7 @@ func TestRandomDueDateHotkey(t *testing.T) {
 		os.Unsetenv("TASKRC")
 	})
 
-	m, err := New(nil)
+	m, err := New(nil, "firefox")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -371,7 +420,7 @@ func TestRecurrenceHotkey(t *testing.T) {
 		os.Unsetenv("TASKRC")
 	})
 
-	m, err := New(nil)
+	m, err := New(nil, "firefox")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -422,7 +471,7 @@ func TestPriorityHotkey(t *testing.T) {
 		os.Unsetenv("TASKRC")
 	})
 
-	m, err := New(nil)
+	m, err := New(nil, "firefox")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -469,7 +518,7 @@ func TestAddHotkey(t *testing.T) {
 		os.Unsetenv("TASKRC")
 	})
 
-	m, err := New(nil)
+	m, err := New(nil, "firefox")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -519,7 +568,7 @@ func TestNavigationHotkeys(t *testing.T) {
 		os.Unsetenv("TASKRC")
 	})
 
-	m, err := New(nil)
+	m, err := New(nil, "firefox")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -576,7 +625,7 @@ func TestEscClosesHelp(t *testing.T) {
 	taskPath := setupBasicTask(t, tmp)
 	setupEnv(t, taskPath)
 
-	m, err := New(nil)
+	m, err := New(nil, "firefox")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -599,7 +648,7 @@ func TestSearchExitHotkeys(t *testing.T) {
 	taskPath := setupBasicTask(t, tmp)
 	setupEnv(t, taskPath)
 
-	m, err := New(nil)
+	m, err := New(nil, "firefox")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}


### PR DESCRIPTION
## Summary
- introduce `browser-cmd` flag
- add hotkey to open first URL in description via external browser
- rename new hotkey from `U` to `o` and restore `U` to undo action
- document new keybindings
- update regression tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685a7c92910c8321840b3a17a1cc61fc